### PR TITLE
Create db_utils with database helpers

### DIFF
--- a/cadastro_equipes.py
+++ b/cadastro_equipes.py
@@ -2,6 +2,7 @@ from tkinter import ttk, messagebox
 
 import customtkinter as ctk
 from database import cursor, conn
+from db_utils import buscar_times
 from tkinter import simpledialog
 
 
@@ -75,8 +76,8 @@ class CadastroTimesFrame(ctk.CTkFrame):
             self.tree.delete(item)
 
         # Buscar times cadastrados
-        cursor.execute("SELECT nome FROM times ORDER BY nome")
-        times = cursor.fetchall()
+        times = buscar_times()
+        times = [(time[1],) for time in times]
 
         # Inserir times na Treeview
         for time in times:

--- a/cadastro_pilotos_categorias.py
+++ b/cadastro_pilotos_categorias.py
@@ -3,6 +3,7 @@ from tkinter import messagebox, StringVar, ttk, simpledialog, END
 from tkinter import Listbox
 import customtkinter as ctk
 from database import cursor, conn
+from db_utils import buscar_categorias, buscar_times
 import sqlite3
 
 # Certifique-se de que as tabelas 'times' e 'pilotos_times' existam no banco de dados.
@@ -205,14 +206,10 @@ class CadastroPilotosFrame(ctk.CTkFrame):
         self.btn_unir_pilotos.pack(pady=10)
 
     def get_categorias(self):
-        cursor.execute("SELECT * FROM categorias ORDER BY nome")
-        categorias = cursor.fetchall()
-        return categorias
+        return buscar_categorias()
 
     def get_times(self):
-        cursor.execute("SELECT * FROM times ORDER BY nome")
-        times = cursor.fetchall()
-        return times
+        return buscar_times()
 
     def carregar_pilotos(self):
         # Limpar a Treeview
@@ -713,14 +710,10 @@ class AdicionarPilotoManualWindow(ctk.CTkToplevel):
         self.btn_salvar.pack(pady=20)
 
     def get_categorias(self):
-        cursor.execute("SELECT * FROM categorias ORDER BY nome")
-        categorias = cursor.fetchall()
-        return categorias
+        return buscar_categorias()
 
     def get_times(self):
-        cursor.execute("SELECT * FROM times ORDER BY nome")
-        times = cursor.fetchall()
-        return times
+        return buscar_times()
 
     def salvar_piloto(self):
         nome = self.entry_nome.get().strip()
@@ -971,14 +964,10 @@ class AdicionarPilotoManualWindow(ctk.CTkToplevel):
         self.btn_salvar.pack(pady=20)
 
     def get_categorias(self):
-        cursor.execute("SELECT * FROM categorias ORDER BY nome")
-        categorias = cursor.fetchall()
-        return categorias
+        return buscar_categorias()
 
     def get_times(self):
-        cursor.execute("SELECT * FROM times ORDER BY nome")
-        times = cursor.fetchall()
-        return times
+        return buscar_times()
 
     def salvar_piloto(self):
         nome = self.entry_nome.get().strip()

--- a/db_utils.py
+++ b/db_utils.py
@@ -1,0 +1,12 @@
+from database import cursor
+
+def buscar_categorias():
+    """Retorna todas as categorias ordenadas pelo nome."""
+    cursor.execute("SELECT * FROM categorias ORDER BY nome")
+    return cursor.fetchall()
+
+
+def buscar_times():
+    """Retorna todos os times ordenados pelo nome."""
+    cursor.execute("SELECT * FROM times ORDER BY nome")
+    return cursor.fetchall()

--- a/frame_resultado_etapas.py
+++ b/frame_resultado_etapas.py
@@ -1,6 +1,7 @@
 from tkinter import StringVar, ttk, messagebox, filedialog
 import customtkinter as ctk
 from database import cursor, conn
+from db_utils import buscar_categorias
 import csv
 import os
 import PyPDF2
@@ -80,9 +81,7 @@ class ResultadosEtapasFrame(ctk.CTkFrame):
         self.atualizar_etapas()
 
     def get_categorias(self):
-        cursor.execute("SELECT * FROM categorias ORDER BY nome")
-        categorias = cursor.fetchall()
-        return categorias
+        return buscar_categorias()
 
     def atualizar_etapas(self, event=None):
         categoria_nome = self.categoria_var.get()

--- a/importar_pilotos.py
+++ b/importar_pilotos.py
@@ -2,6 +2,7 @@ import sqlite3
 
 import customtkinter as ctk
 from database import cursor, conn
+from db_utils import buscar_categorias
 from tkinter import StringVar, messagebox, filedialog
 
 
@@ -33,9 +34,7 @@ class ImportarPilotosFrame(ctk.CTkFrame):
         self.dropdown_categoria.pack(pady=5)
 
     def get_categorias(self):
-        cursor.execute("SELECT * FROM categorias ORDER BY nome")
-        categorias = cursor.fetchall()
-        return categorias
+        return buscar_categorias()
 
     def selecionar_arquivo(self):
         arquivo = filedialog.askopenfilename(title="Selecionar Arquivo",

--- a/resultado_geral_frame.py
+++ b/resultado_geral_frame.py
@@ -6,6 +6,7 @@ from reportlab.lib.pagesizes import landscape, A4
 from reportlab.lib.styles import getSampleStyleSheet
 from reportlab.platypus import Paragraph, Table, TableStyle, SimpleDocTemplate
 from database import cursor, conn
+from db_utils import buscar_categorias
 
 
 class ResultadoGeralFrame(ctk.CTkFrame):
@@ -88,9 +89,7 @@ class ResultadoGeralFrame(ctk.CTkFrame):
         self.atualizar_resultado()
 
     def get_categorias(self):
-        cursor.execute("SELECT * FROM categorias ORDER BY nome")
-        categorias = cursor.fetchall()
-        return categorias
+        return buscar_categorias()
 
     def aplicar_descarte(self, numero_descartes):
         self.atualizar_resultado(descartar=numero_descartes)

--- a/sorteio_karts.py
+++ b/sorteio_karts.py
@@ -1,5 +1,6 @@
 import customtkinter as ctk
 from database import cursor, conn
+from db_utils import buscar_categorias
 from tkinter import StringVar
 from tkinter import ttk, messagebox
 import random
@@ -89,9 +90,7 @@ class SorteioKartsFrame(ctk.CTkFrame):
         self.resultado_label.pack(pady=5)
 
     def get_categorias(self):
-        cursor.execute("SELECT * FROM categorias ORDER BY nome")
-        categorias = cursor.fetchall()
-        return categorias
+        return buscar_categorias()
 
     def atualizar_pilotos(self, event=None):
         categoria_nome = self.categoria_var.get()
@@ -377,9 +376,7 @@ class AdicionarPilotoSorteioWindow(ctk.CTkToplevel):
         self.btn_salvar.pack(pady=20)
 
     def get_categorias(self):
-        cursor.execute("SELECT * FROM categorias ORDER BY nome")
-        categorias = cursor.fetchall()
-        return categorias
+        return buscar_categorias()
 
     def salvar_piloto(self):
         nome = self.entry_nome.get().strip().lower()  # Normaliza o nome para minúsculas


### PR DESCRIPTION
## Summary
- add `db_utils` module with helper queries for categorias and times
- refactor `cadastro_pilotos_categorias` to use the helpers
- update other modules to import the new helper functions

## Testing
- `python -m py_compile db_utils.py cadastro_pilotos_categorias.py frame_resultado_etapas.py importar_pilotos.py resultado_geral_frame.py sorteio_karts.py cadastro_equipes.py`

------
https://chatgpt.com/codex/tasks/task_e_685c6752f570832eb83e796628fd0516