### PR TITLE
Remove duplicate DB integrity helper

### DIFF
--- a/database.py
+++ b/database.py
@@ -104,13 +104,3 @@ def verificar_ou_adicionar_coluna_corrida_de_times():
             print("Coluna corrida_de_times já existe.")
     except Exception as e:
         print(f"Erro ao verificar ou adicionar a coluna corrida_de_times: {e}")
-def verificar_estrutura_banco():
-    # Verificar se a coluna 'adv' existe na tabela 'resultados_etapas'
-    cursor.execute("PRAGMA table_info(resultados_etapas)")
-    colunas = [info[1] for info in cursor.fetchall()]
-
-    # Se a coluna 'adv' não existir, adicioná-la
-    if 'adv' not in colunas:
-        cursor.execute("ALTER TABLE resultados_etapas ADD COLUMN adv INTEGER DEFAULT 0")
-        conn.commit()
-        print("Coluna 'adv' adicionada com sucesso à tabela 'resultados_etapas'.")


### PR DESCRIPTION
## Summary
- clean up `database.py` by dropping the second definition of `verificar_estrutura_banco`
- keep `setup_database()` calling this single helper

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_685c64a1afb0832ea8a67a061abe18cb